### PR TITLE
Add gbif name to declines.csv

### DIFF
--- a/data/declines.csv
+++ b/data/declines.csv
@@ -1,146 +1,146 @@
-species,mean
-Phyciodes campestris campestris/montana,-2.248001336
-Lycaena rubidus,-0.987884743
-Pholisora catullus,-0.974564169
-Hesperia nevada,-0.88391926
-Vanessa annabella,-0.866599286
-Euchloe ausonides,-0.847897425
-Polites sabuleti sabuleti,-0.74624448
-Euchloe hyantis lotta,-0.739045882
-Phyciodes campestris campestris,-0.700018504
-Colias alexandra,-0.685079824
-Pontia protodice,-0.654475498
-Coenonympha tullia california,-0.636284692
-Polygonia faunus,-0.627875769
-Plebejus shasta,-0.614791937
-Leptotes marina,-0.589828498
-Pyrgus scriptura,-0.530699808
-Nymphalis milberti,-0.517827747
-Lycaena xanthoides,-0.516145563
-Lerodea eufala,-0.495305877
-Polites sabuleti tecumseh,-0.490976826
-Nymphalis antiopa,-0.482808947
-Danaus plexippus,-0.464710487
-Lycaeides melissa melissa,-0.461411373
-Papilio zelicaon,-0.451452546
-Polygonia satyrus,-0.445972639
-Oeneis chryxus ivallda,-0.43568731
-Lycaena helloides,-0.414717439
-Amblyscirtes vialis,-0.412402092
-Anthocharis sara sara,-0.395182941
-Papilio indra,-0.382923245
-Philotes sonorensis,-0.356603414
-Pontia occidentalis,-0.353512284
-Vanessa virginiensis,-0.346722441
-Colias philodice (eriphyle),-0.346569632
-Lycaena mariposa,-0.336547179
-Neophasia menapia,-0.330980428
-Euphydryas chalcedona,-0.328637364
-Atlides halesus,-0.320444774
-Brephidium exile,-0.29320035
-Apodemia mormo,-0.28859379
-Polygonia zephyrus,-0.287637157
-Satyrium auretorum,-0.281909986
-Satyrium sylvinus,-0.278754873
-Cercyonis sthenele silvestris,-0.275765744
-Lycaena arota arota,-0.274156707
-Thorybes mexicana nevada,-0.273661099
-Speyeria cybele leto,-0.273326249
-Lycaena gorgon,-0.271646927
-Lycaena heteronea,-0.271563615
-Colias eurytheme,-0.271397483
-Anthocharis sara thoosa,-0.259073225
-Vanessa atalanta,-0.249177722
-Pontia sisymbrii,-0.248310131
-Satyrium tetra,-0.246927117
-Mitoura gryneus chalcosiva,-0.242140002
-Lycaena cupreus,-0.235019382
-Coenonympha tullia ampelos,-0.234282134
-Lycaena nivalis,-0.228809188
-Pieris rapae,-0.223634284
-Papilio multicaudatus,-0.204080237
-Callophrys dumetorum,-0.201690826
-Glaucopsyche lygdamus,-0.201664996
-Atalopedes campestris,-0.1987905
-Everes amyntula,-0.195853714
-Hesperia colorado harpalus,-0.19532684
-Satyrium saepium,-0.184503023
-Erynnis persius,-0.18355564
-Speyeria egleis,-0.181009441
-Glaucopsyche piasus,-0.17855243
-Euchloe hyantis hyantis,-0.168094376
-Hesperia lindseyi,-0.16580606
-Strymon melinus,-0.165254699
-Celastrina ladon echo,-0.15141772
-Everes comyntas,-0.147252965
-Hesperia juba,-0.144507215
-Hylephila phyleus,-0.143006838
-Thorybes pylades,-0.140434639
-Satyrium fuliginosum fuliginosum,-0.138777683
-Erynnis propertius,-0.136434725
-Polites sonora,-0.135892316
-Pyrgus communis,-0.133070825
-Speyeria callippe nevadensis,-0.128529135
-Cercyonis oetus,-0.128267405
-Ochlodes sylvanoides,-0.123360432
-Anthocharis lanceolata,-0.120883861
-Habrodais grunus,-0.120283654
-Incisalia mossii,-0.11901563
-Plebejus acmon,-0.115354662
-Plebejus icarioides,-0.112839271
-Euphydryas editha,-0.111518749
-Hesperia colorado idaho,-0.106052756
-Pontia beckerii,-0.101549058
-Nymphalis californica,-0.097292162
-Satyrium californica,-0.088271304
-Adelpha bredowii californica,-0.087111961
-Pieris napi,-0.084543532
-Erynnis tristis,-0.076206965
-Erynnis icelus,-0.071172877
-Euphilotes enoptes,-0.069783693
-Chlosyne palla,-0.069612313
-Ochlodes agricola,-0.06867095
-Ochlodes yuma,-0.06695505
-Plebejus saepiolus,-0.066508089
-Phyciodes mylitta,-0.065002154
-Satyrium behrii,-0.057482096
-Plebejus lupini,-0.057199979
-Limenitis lorquini,-0.050217676
-Vanessa cardui,-0.049515982
-Incisalia augustinus iroides,-0.044720506
-Junonia coenia,-0.026935997
-Heliopetes ericetorum,-0.017913677
-Hesperia columbia,-0.015628568
-"Euchloe hyantis """"""""foothill""""""""",-0.014122047
-Callophrys sheridanii lemberti,0.000385441
-Boloria epithore,0.003162292
-Papilio eurymedon,0.017690353
-Lycaena arota virginiensis,0.024106472
-Speyeria hydaspe,0.039987664
-Lycaena editha,0.050486554
-Speyeria zerene,0.05624673
-Speyeria mormonia,0.058979646
-Parnassius clodius,0.067358757
-Mitoura gryneus nelsoni,0.078333581
-Poanes melane,0.080185118
-Anthocharis stella,0.096113461
-Pyrgus ruralis,0.105325837
-Speyeria callippe juba,0.111004047
-Speyeria atlantis irene,0.111257852
-Zerene eurydice,0.118259949
-Phyciodes campestris montana,0.124293478
-Papilio rutulus,0.125043005
-Polites sabuleti ssp.,0.129652007
-Phyciodes orseis herlani,0.134132196
-Lycaeides idas anna,0.143620588
-Battus philenor,0.1726922
-Incisalia eryphon,0.19706876
-Chlosyne hoffmanni,0.289231777
-Hesperia colorado ssp.,0.331623977
-Euphilotes battoides,0.342635941
-Agriades podarce,0.351609298
-Thessalia leanira,0.444313135
-Speyeria coronis,0.466216372
-Epargyreus clarus,0.499870865
-Cercyonis pegala boopis,0.780195401
-Agraulis vanillae,4.398083555
+species,mean,gbif_name
+Phyciodes campestris campestris/montana,-2.248001336,Phyciodes campestris campestris/montana
+Lycaena rubidus,-0.987884743,Lycaena rubidus
+Pholisora catullus,-0.974564169,Pholisora catullus
+Hesperia nevada,-0.88391926,Hesperia nevada
+Vanessa annabella,-0.866599286,Vanessa annabella
+Euchloe ausonides,-0.847897425,Euchloe ausonides
+Polites sabuleti sabuleti,-0.74624448,Polites sabuleti sabuleti
+Euchloe hyantis lotta,-0.739045882,Euchloe hyantis lotta
+Phyciodes campestris campestris,-0.700018504,Phyciodes campestris campestris
+Colias alexandra,-0.685079824,Colias alexandra
+Pontia protodice,-0.654475498,Pontia protodice
+Coenonympha tullia california,-0.636284692,Coenonympha tullia california
+Polygonia faunus,-0.627875769,Polygonia faunus
+Plebejus shasta,-0.614791937,Plebejus shasta
+Leptotes marina,-0.589828498,Leptotes marina
+Pyrgus scriptura,-0.530699808,Pyrgus scriptura
+Nymphalis milberti,-0.517827747,Nymphalis milberti
+Lycaena xanthoides,-0.516145563,Lycaena xanthoides
+Lerodea eufala,-0.495305877,Lerodea eufala
+Polites sabuleti tecumseh,-0.490976826,Polites sabuleti tecumseh
+Nymphalis antiopa,-0.482808947,Nymphalis antiopa
+Danaus plexippus,-0.464710487,Danaus plexippus
+Lycaeides melissa melissa,-0.461411373,Lycaeides melissa melissa
+Papilio zelicaon,-0.451452546,Papilio zelicaon
+Polygonia satyrus,-0.445972639,Polygonia satyrus
+Oeneis chryxus ivallda,-0.43568731,Oeneis chryxus ivallda
+Lycaena helloides,-0.414717439,Lycaena helloides
+Amblyscirtes vialis,-0.412402092,Amblyscirtes vialis
+Anthocharis sara sara,-0.395182941,Anthocharis sara sara
+Papilio indra,-0.382923245,Papilio indra
+Philotes sonorensis,-0.356603414,Philotes sonorensis
+Pontia occidentalis,-0.353512284,Pontia occidentalis
+Vanessa virginiensis,-0.346722441,Vanessa virginiensis
+Colias philodice (eriphyle),-0.346569632,Colias philodice (eriphyle)
+Lycaena mariposa,-0.336547179,Lycaena mariposa
+Neophasia menapia,-0.330980428,Neophasia menapia
+Euphydryas chalcedona,-0.328637364,Euphydryas chalcedona
+Atlides halesus,-0.320444774,Atlides halesus
+Brephidium exile,-0.29320035,Brephidium exile
+Apodemia mormo,-0.28859379,Apodemia mormo
+Polygonia zephyrus,-0.287637157,Polygonia zephyrus
+Satyrium auretorum,-0.281909986,Satyrium auretorum
+Satyrium sylvinus,-0.278754873,Satyrium sylvinus
+Cercyonis sthenele silvestris,-0.275765744,Cercyonis sthenele silvestris
+Lycaena arota arota,-0.274156707,Lycaena arota arota
+Thorybes mexicana nevada,-0.273661099,Thorybes mexicana nevada
+Speyeria cybele leto,-0.273326249,Speyeria cybele leto
+Lycaena gorgon,-0.271646927,Lycaena gorgon
+Lycaena heteronea,-0.271563615,Lycaena heteronea
+Colias eurytheme,-0.271397483,Colias eurytheme
+Anthocharis sara thoosa,-0.259073225,Anthocharis sara thoosa
+Vanessa atalanta,-0.249177722,Vanessa atalanta
+Pontia sisymbrii,-0.248310131,Pontia sisymbrii
+Satyrium tetra,-0.246927117,Satyrium tetra
+Mitoura gryneus chalcosiva,-0.242140002,Callophrys gryneus chalcosiva
+Lycaena cupreus,-0.235019382,Lycaena cupreus
+Coenonympha tullia ampelos,-0.234282134,Coenonympha tullia ampelos
+Lycaena nivalis,-0.228809188,Lycaena nivalis
+Pieris rapae,-0.223634284,Pieris rapae
+Papilio multicaudatus,-0.204080237,Papilio multicaudata
+Callophrys dumetorum,-0.201690826,Callophrys dumetorum
+Glaucopsyche lygdamus,-0.201664996,Glaucopsyche lygdamus
+Atalopedes campestris,-0.1987905,Atalopedes campestris
+Everes amyntula,-0.195853714,Everes amyntula
+Hesperia colorado harpalus,-0.19532684,Hesperia colorado harpalus
+Satyrium saepium,-0.184503023,Satyrium saepium
+Erynnis persius,-0.18355564,Erynnis persius
+Speyeria egleis,-0.181009441,Speyeria egleis
+Glaucopsyche piasus,-0.17855243,Glaucopsyche piasus
+Euchloe hyantis hyantis,-0.168094376,Euchloe hyantis hyantis
+Hesperia lindseyi,-0.16580606,Hesperia lindseyi
+Strymon melinus,-0.165254699,Strymon melinus
+Celastrina ladon echo,-0.15141772,Celastrina ladon echo
+Everes comyntas,-0.147252965,Everes comyntas
+Hesperia juba,-0.144507215,Hesperia juba
+Hylephila phyleus,-0.143006838,Hylephila phyleus
+Thorybes pylades,-0.140434639,Thorybes pylades
+Satyrium fuliginosum fuliginosum,-0.138777683,Satyrium fuliginosa fuliginosa
+Erynnis propertius,-0.136434725,Erynnis propertius
+Polites sonora,-0.135892316,Polites sonora
+Pyrgus communis,-0.133070825,Pyrgus communis
+Speyeria callippe nevadensis,-0.128529135,Speyeria callippe nevadensis
+Cercyonis oetus,-0.128267405,Cercyonis oetus
+Ochlodes sylvanoides,-0.123360432,Ochlodes sylvanoides
+Anthocharis lanceolata,-0.120883861,Anthocharis lanceolata
+Habrodais grunus,-0.120283654,Habrodais grunus
+Incisalia mossii,-0.11901563,Callophrys mossii
+Plebejus acmon,-0.115354662,Plebejus acmon
+Plebejus icarioides,-0.112839271,Plebejus icarioides
+Euphydryas editha,-0.111518749,Euphydryas editha
+Hesperia colorado idaho,-0.106052756,Hesperia colorado idaho
+Pontia beckerii,-0.101549058,Pontia beckerii
+Nymphalis californica,-0.097292162,Nymphalis californica
+Satyrium californica,-0.088271304,Satyrium californica
+Adelpha bredowii californica,-0.087111961,Adelpha californica
+Pieris napi,-0.084543532,Pieris napi
+Erynnis tristis,-0.076206965,Erynnis tristis
+Erynnis icelus,-0.071172877,Erynnis icelus
+Euphilotes enoptes,-0.069783693,Euphilotes enoptes
+Chlosyne palla,-0.069612313,Chlosyne palla
+Ochlodes agricola,-0.06867095,Ochlodes agricola
+Ochlodes yuma,-0.06695505,Ochlodes yuma
+Plebejus saepiolus,-0.066508089,Plebejus saepiolus
+Phyciodes mylitta,-0.065002154,Phyciodes mylitta
+Satyrium behrii,-0.057482096,Satyrium behrii
+Plebejus lupini,-0.057199979,Plebejus lupini
+Limenitis lorquini,-0.050217676,Limenitis lorquini
+Vanessa cardui,-0.049515982,Vanessa cardui
+Incisalia augustinus iroides,-0.044720506,Callophrys augustinus iroides
+Junonia coenia,-0.026935997,Junonia coenia
+Heliopetes ericetorum,-0.017913677,Heliopetes ericetorum
+Hesperia columbia,-0.015628568,Hesperia columbia
+"Euchloe hyantis """"""""foothill""""""""",-0.014122047,NA
+Callophrys sheridanii lemberti,0.000385441,Callophrys sheridanii lemberti
+Boloria epithore,0.003162292,Boloria epithore
+Papilio eurymedon,0.017690353,Papilio eurymedon
+Lycaena arota virginiensis,0.024106472,Lycaena arota virginiensis
+Speyeria hydaspe,0.039987664,Speyeria hydaspe
+Lycaena editha,0.050486554,Lycaena editha
+Speyeria zerene,0.05624673,Speyeria zerene
+Speyeria mormonia,0.058979646,Speyeria mormonia
+Parnassius clodius,0.067358757,Parnassius clodius
+Mitoura gryneus nelsoni,0.078333581,Callophrys gryneus nelsoni
+Poanes melane,0.080185118,Poanes melane
+Anthocharis stella,0.096113461,Anthocharis stella
+Pyrgus ruralis,0.105325837,Pyrgus ruralis
+Speyeria callippe juba,0.111004047,Speyeria callippe juba
+Speyeria atlantis irene,0.111257852,Speyeria atlantis irene
+Zerene eurydice,0.118259949,Zerene eurydice
+Phyciodes campestris montana,0.124293478,Phyciodes montana
+Papilio rutulus,0.125043005,Papilio rutulus
+Polites sabuleti ssp.,0.129652007,NA
+Phyciodes orseis herlani,0.134132196,Phyciodes herlani
+Lycaeides idas anna,0.143620588,Plebejus anna
+Battus philenor,0.1726922,Battus philenor
+Incisalia eryphon,0.19706876,Incisalia eryphon
+Chlosyne hoffmanni,0.289231777,Chlosyne hoffmanni
+Hesperia colorado ssp.,0.331623977,NA
+Euphilotes battoides,0.342635941,Euphilotes battoides
+Agriades podarce,0.351609298,Agriades glandon podarce
+Thessalia leanira,0.444313135,Thessalia leanira
+Speyeria coronis,0.466216372,Speyeria coronis
+Epargyreus clarus,0.499870865,Epargyreus clarus
+Cercyonis pegala boopis,0.780195401,Cercyonis pegala boopis
+Agraulis vanillae,4.398083555,Agraulis vanillae


### PR DESCRIPTION
Added another column, `gbif_names` to the data/declines.csv file. Should be useful for pulling records. Note some of the species (e.g. _Hesperia colorado_ ssp.) won't have synonyms on GBIF, and have been marked as `NA`. Others yet may have synonyms, but no records, on GBIF.
